### PR TITLE
Handle legacy splice command length

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,14 +247,12 @@ Example JSON output:
   "table_id": 252,
   "section_syntax_indicator": 0,
   "private_indicator": 0,
-  "section_length": 22,
   "protocol_version": 0,
   "encrypted_packet": 0,
   "encryption_algorithm": 0,
   "pts_adjustment": 0,
   "cw_index": 255,
   "tier": 4095,
-  "splice_command_length": 5,
   "splice_command_type": 6,
   "splice_command": {
     "type": "TimeSignal",
@@ -268,7 +266,6 @@ Example JSON output:
       }
     }
   },
-  "descriptor_loop_length": 0,
   "splice_descriptors": [],
   "alignment_stuffing_bits": "",
   "e_crc_32": null,
@@ -363,7 +360,10 @@ let section = SpliceInfoSectionBuilder::new()
     .splice_insert(splice_insert)
     .build()?;
 
-println!("Created SCTE-35 message with {} byte payload", section.section_length);
+println!(
+    "Created SCTE-35 message with command type 0x{:02x}",
+    section.splice_command_type
+);
 # Ok(())
 # }
 ```
@@ -581,10 +581,8 @@ cargo run --features cli -- -o json "/DAvAAAAAAAA///wFAVIAACPf+/+c2nALv4AUsz1AAA
   "status": "success",
   "data": {
     "table_id": 252,
-    "section_length": 47,
     "protocol_version": 0,
     "splice_command_type": 5,
-    "splice_command_length": 20,
     "splice_command": {
       "type": "SpliceInsert",
       "splice_event_id": 1207959695,
@@ -615,7 +613,6 @@ cargo run --features cli -- -o json "/DAvAAAAAAAA///wFAVIAACPf+/+c2nALv4AUsz1AAA
       "avail_num": 0,
       "avails_expected": 0
     },
-    "descriptor_loop_length": 10,
     "splice_descriptors": [
       {
         "descriptor_type": "Unknown",
@@ -689,7 +686,6 @@ cargo doc --no-deps --open
 Convenient alias for parsing SCTE-35 messages. This is the recommended function for most use cases, providing a clean and ergonomic API.
 
 ```rust
-# use scte35;
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
 # #[cfg(feature = "cli")]
 # {
@@ -723,13 +719,15 @@ Validates the CRC-32 checksum of an SCTE-35 message independently. Returns `Ok(t
 #### `SpliceInfoSection`
 The top-level structure containing all SCTE-35 message fields:
 - `table_id`: Table identifier (should be 0xFC for SCTE-35)
-- `section_length`: Length of the section
 - `protocol_version`: SCTE-35 protocol version
 - `splice_command_type`: Type of splice command
 - `splice_command`: The actual command data (enum)
-- `descriptor_loop_length`: Length of descriptors
 - `splice_descriptors`: List of splice descriptors
 - `crc_32`: CRC32 checksum
+
+Wire length fields such as `section_length`, `splice_command_length`, and
+`descriptor_loop_length` are parsed and validated internally, and are computed
+when encoding.
 
 #### `SpliceCommand`
 An enum representing different SCTE-35 command types:

--- a/examples/builder_demo.rs
+++ b/examples/builder_demo.rs
@@ -29,7 +29,7 @@ fn main() -> BuilderResult<()> {
         section.splice_command.get_event_id().unwrap_or(0)
     );
     println!("   Command Type: 0x{:02x}", section.splice_command_type);
-    println!("   Section Length: {} bytes\n", section.section_length);
+    println!();
 
     // Example 2: Creating a Time Signal with Segmentation Descriptor
     println!("2. Creating a program start boundary with UPID:");
@@ -57,10 +57,7 @@ fn main() -> BuilderResult<()> {
             .unwrap_or(0)
     );
     println!("   Descriptors: {}", section.splice_descriptors.len());
-    println!(
-        "   Descriptor Loop Length: {} bytes\n",
-        section.descriptor_loop_length
-    );
+    println!();
 
     // Example 3: Creating an Immediate Splice Out
     println!("3. Creating an immediate splice out to ads:");

--- a/examples/builder_demo.rs
+++ b/examples/builder_demo.rs
@@ -185,6 +185,7 @@ fn main() -> BuilderResult<()> {
         }
         Err(e) => println!("   Unexpected error: {e}"),
     }
+    println!();
 
     // Example 7: MPU UPID usage patterns
     println!("7. Creating MPU UPIDs for different use cases:");

--- a/plans/CREATE_SCTE_EVENT.md
+++ b/plans/CREATE_SCTE_EVENT.md
@@ -146,6 +146,20 @@ impl SpliceInfoSectionBuilder {
     pub fn build(self) -> BuilderResult<SpliceInfoSection> {
         let splice_command = self.splice_command
             .ok_or(BuilderError::MissingRequiredField("splice_command"))?;
+        let splice_command_type = match &splice_command {
+            SpliceCommand::SpliceNull => 0x00,
+            SpliceCommand::SpliceSchedule(_) => 0x04,
+            SpliceCommand::SpliceInsert(_) => 0x05,
+            SpliceCommand::TimeSignal(_) => 0x06,
+            SpliceCommand::BandwidthReservation(_) => 0x07,
+            SpliceCommand::PrivateCommand(_) => 0xFF,
+            SpliceCommand::Unknown => {
+                return Err(BuilderError::InvalidValue {
+                    field: "splice_command",
+                    reason: "unknown splice commands cannot be built".to_string(),
+                });
+            }
+        };
 
         // Calculate section_length and other derived fields
         let splice_command_length = splice_command.encoded_length();
@@ -167,7 +181,7 @@ impl SpliceInfoSectionBuilder {
             cw_index: 0,  // Not exposing encryption
             tier: self.tier,
             splice_command_length,
-            splice_command_type: (&splice_command).into(),
+            splice_command_type,
             splice_command,
             descriptor_loop_length,
             splice_descriptors: self.descriptors,
@@ -730,21 +744,6 @@ impl SpliceCommand {
             }
             SpliceCommand::PrivateCommand(pc) => pc.private_command_length as u16 + 3,
             SpliceCommand::Unknown => 0,
-        }
-    }
-}
-
-// Convert SpliceCommand reference to command type byte
-impl From<&SpliceCommand> for u8 {
-    fn from(command: &SpliceCommand) -> Self {
-        match command {
-            SpliceCommand::SpliceNull => 0x00,
-            SpliceCommand::SpliceSchedule(_) => 0x04,
-            SpliceCommand::SpliceInsert(_) => 0x05,
-            SpliceCommand::TimeSignal(_) => 0x06,
-            SpliceCommand::BandwidthReservation(_) => 0x07,
-            SpliceCommand::PrivateCommand(_) => 0xFF,
-            SpliceCommand::Unknown => 0xFF,
         }
     }
 }

--- a/src/builders/descriptors.rs
+++ b/src/builders/descriptors.rs
@@ -241,13 +241,11 @@ impl SegmentationDescriptorBuilder {
                     });
                 }
             }
-            Upid::Reserved(_, data) => {
-                if data.len() > 255 {
-                    return Err(BuilderError::InvalidValue {
-                        field: "reserved_upid_data",
-                        reason: "Reserved UPID data must be <= 255 bytes".to_string(),
-                    });
-                }
+            Upid::Reserved(_, data) if data.len() > 255 => {
+                return Err(BuilderError::InvalidValue {
+                    field: "reserved_upid_data",
+                    reason: "Reserved UPID data must be <= 255 bytes".to_string(),
+                });
             }
             _ => {} // Other types have fixed sizes
         }

--- a/src/builders/extensions.rs
+++ b/src/builders/extensions.rs
@@ -19,14 +19,6 @@ impl SpliceCommandExt for SpliceCommand {
 /// Convert SpliceCommand reference to command type byte.
 impl From<&SpliceCommand> for u8 {
     fn from(command: &SpliceCommand) -> Self {
-        match command {
-            SpliceCommand::SpliceNull => 0x00,
-            SpliceCommand::SpliceSchedule(_) => 0x04,
-            SpliceCommand::SpliceInsert(_) => 0x05,
-            SpliceCommand::TimeSignal(_) => 0x06,
-            SpliceCommand::BandwidthReservation(_) => 0x07,
-            SpliceCommand::PrivateCommand(_) => 0xFF,
-            SpliceCommand::Unknown => 0xFF,
-        }
+        command.command_type()
     }
 }

--- a/src/builders/extensions.rs
+++ b/src/builders/extensions.rs
@@ -15,10 +15,3 @@ impl SpliceCommandExt for SpliceCommand {
         self.encoded_size() as u16
     }
 }
-
-/// Convert SpliceCommand reference to command type byte.
-impl From<&SpliceCommand> for u8 {
-    fn from(command: &SpliceCommand) -> Self {
-        command.command_type()
-    }
-}

--- a/src/builders/splice_info_section.rs
+++ b/src/builders/splice_info_section.rs
@@ -101,50 +101,28 @@ impl SpliceInfoSectionBuilder {
         let splice_command = self
             .splice_command
             .ok_or(BuilderError::MissingRequiredField("splice_command"))?;
+        let splice_command_type = splice_command.command_type();
 
-        // Get the actual command type
-        let splice_command_type: u8 = (&splice_command).into();
-
-        // Import the Encodable trait to get access to encoded sizes
-        use crate::encoding::Encodable;
-
-        // Calculate descriptor_loop_length correctly
-        let mut descriptor_loop_length = 0u16;
-        for descriptor in &self.descriptors {
-            // Each descriptor contributes its full encoded size
-            descriptor_loop_length += descriptor.encoded_size() as u16;
-        }
-
-        // Build the section with proper defaults
-        let mut section = SpliceInfoSection {
+        // Build the section with proper defaults. Length fields are derived
+        // during encoding and are intentionally not stored in the API model.
+        let section = SpliceInfoSection {
             table_id: 0xFC,              // Fixed per spec
             section_syntax_indicator: 0, // Fixed per spec
             private_indicator: 0,        // Fixed per spec
             sap_type: 0x3,               // Fixed per spec (undefined)
-            section_length: 0,           // Will be calculated during encoding
             protocol_version: 0,         // Current version
             encrypted_packet: 0,         // Not encrypted
             encryption_algorithm: 0,     // No encryption
             pts_adjustment: self.pts_adjustment,
             cw_index: self.cw_index,
             tier: self.tier,
-            splice_command_length: 0, // Will be calculated during encoding
             splice_command_type,
             splice_command,
-            descriptor_loop_length: 0, // Will be calculated during encoding
             splice_descriptors: self.descriptors,
             alignment_stuffing_bits: Vec::new(), // No stuffing by default
             e_crc_32: None,                      // Not encrypted
             crc_32: 0,                           // Will be calculated during encoding
         };
-
-        // Calculate the actual lengths now that we have the full structure
-        section.splice_command_length = section.splice_command.encoded_size() as u16;
-        section.descriptor_loop_length = descriptor_loop_length;
-
-        // Section length is the total size minus the first 3 bytes
-        // (table_id + section_syntax_indicator/private_indicator/sap_type + section_length itself)
-        section.section_length = (section.encoded_size() - 3) as u16;
 
         Ok(section)
     }

--- a/src/builders/splice_info_section.rs
+++ b/src/builders/splice_info_section.rs
@@ -96,12 +96,26 @@ impl SpliceInfoSectionBuilder {
     ///
     /// # Errors
     ///
-    /// Returns an error if no splice command has been set.
+    /// Returns an error if no splice command has been set or an unknown
+    /// command is supplied.
     pub fn build(self) -> BuilderResult<SpliceInfoSection> {
         let splice_command = self
             .splice_command
             .ok_or(BuilderError::MissingRequiredField("splice_command"))?;
-        let splice_command_type = splice_command.command_type();
+        let splice_command_type = match &splice_command {
+            SpliceCommand::SpliceNull => 0x00,
+            SpliceCommand::SpliceSchedule(_) => 0x04,
+            SpliceCommand::SpliceInsert(_) => 0x05,
+            SpliceCommand::TimeSignal(_) => 0x06,
+            SpliceCommand::BandwidthReservation(_) => 0x07,
+            SpliceCommand::PrivateCommand(_) => 0xFF,
+            SpliceCommand::Unknown => {
+                return Err(BuilderError::InvalidValue {
+                    field: "splice_command",
+                    reason: "unknown splice commands cannot be built".to_string(),
+                });
+            }
+        };
 
         // Build the section with proper defaults. Length fields are derived
         // during encoding and are intentionally not stored in the API model.

--- a/src/builders/tests.rs
+++ b/src/builders/tests.rs
@@ -1166,7 +1166,6 @@ mod builder_tests {
 
         // Verify key fields
         assert_eq!(reparsed_section.splice_command_type, 0x00); // SpliceNull
-        assert_eq!(reparsed_section.section_length, 17); // Expected section length
         if let crate::types::SpliceCommand::SpliceNull = &reparsed_section.splice_command {
             // SpliceNull has no additional fields to verify
         } else {

--- a/src/builders/tests.rs
+++ b/src/builders/tests.rs
@@ -501,6 +501,22 @@ mod builder_tests {
     }
 
     #[test]
+    fn test_splice_info_section_builder_rejects_unknown_command() {
+        let result = SpliceInfoSectionBuilder::new()
+            .splice_command(crate::types::SpliceCommand::Unknown)
+            .build();
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            BuilderError::InvalidValue { field, reason } => {
+                assert_eq!(field, "splice_command");
+                assert_eq!(reason, "unknown splice commands cannot be built");
+            }
+            _ => panic!("Expected InvalidValue error"),
+        }
+    }
+
+    #[test]
     fn test_splice_null_command() {
         let section = SpliceInfoSectionBuilder::new()
             .splice_null()

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -9,7 +9,9 @@ use crate::types::{
     BandwidthReservation, ComponentSplice, PrivateCommand, SpliceCommand, SpliceInsert,
     SpliceInsertComponent, SpliceSchedule, TimeSignal,
 };
-use std::io;
+use std::io::{self, ErrorKind};
+
+pub(crate) const LEGACY_SPLICE_COMMAND_LENGTH: u16 = 0x0FFF;
 
 /// Parses a splice command based on the command type.
 ///
@@ -34,8 +36,16 @@ pub(crate) fn parse_splice_command(
             reader,
         )?)),
         _ => {
-            // Unknown command type - skip the data
-            reader.skip_bits((splice_command_length * 8) as usize)?;
+            if splice_command_length == LEGACY_SPLICE_COMMAND_LENGTH {
+                return Err(io::Error::new(
+                    ErrorKind::InvalidData,
+                    format!(
+                        "Cannot parse unknown splice command type 0x{splice_command_type:02X} with legacy splice_command_length 0xFFF"
+                    ),
+                ));
+            }
+
+            reader.skip_bits(splice_command_length as usize * 8)?;
             Ok(SpliceCommand::Unknown)
         }
     }

--- a/src/encoding/commands.rs
+++ b/src/encoding/commands.rs
@@ -15,10 +15,7 @@ impl Encodable for SpliceCommand {
             SpliceCommand::TimeSignal(signal) => signal.encode(writer),
             SpliceCommand::BandwidthReservation(reservation) => reservation.encode(writer),
             SpliceCommand::PrivateCommand(private) => private.encode(writer),
-            SpliceCommand::Unknown => {
-                // Unknown command has no defined encoding
-                Ok(())
-            }
+            SpliceCommand::Unknown => Ok(()),
         }
     }
 

--- a/src/encoding/round_trip_tests.rs
+++ b/src/encoding/round_trip_tests.rs
@@ -87,7 +87,6 @@ mod tests {
 
         println!("Parsed section successfully");
         println!("  Table ID: {}", section.table_id);
-        println!("  Section Length: {}", section.section_length);
         println!("  Command Type: {}", section.splice_command_type);
 
         // Encode back to binary with CRC
@@ -266,17 +265,14 @@ mod tests {
             section_syntax_indicator: 0,
             private_indicator: 0,
             sap_type: 3,
-            section_length: 0, // Will be calculated during encoding
             protocol_version: 0,
             encrypted_packet: 0,
             encryption_algorithm: 0,
             pts_adjustment: 0,
             cw_index: 0xFF,
             tier: 0xFFF,
-            splice_command_length: 0, // Will be calculated during encoding
-            splice_command_type: 7,
+            splice_command_type: 0x07,
             splice_command: SpliceCommand::BandwidthReservation(bandwidth_reservation),
-            descriptor_loop_length: 0,
             splice_descriptors: Vec::new(),
             alignment_stuffing_bits: Vec::new(),
             e_crc_32: None,
@@ -307,17 +303,14 @@ mod tests {
             section_syntax_indicator: 0,
             private_indicator: 0,
             sap_type: 3,
-            section_length: 0, // Will be calculated during encoding
             protocol_version: 0,
             encrypted_packet: 0,
             encryption_algorithm: 0,
             pts_adjustment: 0,
             cw_index: 0xFF,
             tier: 0xFFF,
-            splice_command_length: 0, // Will be calculated during encoding
             splice_command_type: 0xFF,
             splice_command: SpliceCommand::PrivateCommand(private_command),
-            descriptor_loop_length: 0,
             splice_descriptors: Vec::new(),
             alignment_stuffing_bits: Vec::new(),
             e_crc_32: None,
@@ -498,7 +491,6 @@ mod tests {
         // Basic sanity checks
         assert_eq!(section.table_id, reparsed.table_id);
         assert_eq!(section.splice_command_type, reparsed.splice_command_type);
-        assert_eq!(section.section_length, reparsed.section_length);
 
         println!("Original:  {original_payload}");
         println!("Re-encoded: {encoded_base64}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,12 +60,12 @@ fn print_text_output(section: &SpliceInfoSection, buffer: &[u8]) {
             println!("    Duration Flag: {}", cmd.duration_flag);
             println!("    Splice Immediate Flag: {}", cmd.splice_immediate_flag);
 
-            if let Some(splice_time) = &cmd.splice_time {
-                if let Some(pts) = splice_time.pts_time {
-                    println!("    Splice Time PTS: 0x{pts:09x}");
-                    if let Some(duration) = splice_time.to_duration() {
-                        println!("    Splice Time: {:.6} seconds", duration.as_secs_f64());
-                    }
+            if let Some(splice_time) = &cmd.splice_time
+                && let Some(pts) = splice_time.pts_time
+            {
+                println!("    Splice Time PTS: 0x{pts:09x}");
+                if let Some(duration) = splice_time.to_duration() {
+                    println!("    Splice Time: {:.6} seconds", duration.as_secs_f64());
                 }
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,10 +30,8 @@ struct Arguments {
 fn print_text_output(section: &SpliceInfoSection, buffer: &[u8]) {
     println!("Successfully parsed SpliceInfoSection:");
     println!("  Table ID: {}", section.table_id);
-    println!("  Section Length: {}", section.section_length);
     println!("  Protocol Version: {}", section.protocol_version);
     println!("  Splice Command Type: {}", section.splice_command_type);
-    println!("  Splice Command Length: {}", section.splice_command_length);
 
     match &section.splice_command {
         SpliceCommand::SpliceNull => {
@@ -102,14 +100,13 @@ fn print_text_output(section: &SpliceInfoSection, buffer: &[u8]) {
             println!("    Private Command Length: {}", cmd.private_command_length);
         }
         SpliceCommand::Unknown => {
-            println!("  Splice Command: Unknown");
+            println!(
+                "  Splice Command: Unknown (0x{:02x})",
+                section.splice_command_type
+            );
         }
     }
 
-    println!(
-        "  Descriptor Loop Length: {}",
-        section.descriptor_loop_length
-    );
     println!(
         "  Number of Descriptors: {}",
         section.splice_descriptors.len()

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,7 +4,7 @@
 //! and related structures.
 
 use crate::bit_reader::BitReader;
-use crate::commands::parse_splice_command;
+use crate::commands::{LEGACY_SPLICE_COMMAND_LENGTH, parse_splice_command};
 use crate::descriptors::{SegmentationDescriptor, SpliceDescriptor};
 use crate::types::{SegmentationType, SpliceInfoSection};
 use crate::upid::SegmentationUpidType;
@@ -73,12 +73,19 @@ pub fn parse_splice_info_section(buffer: &[u8]) -> Result<SpliceInfoSection, io:
         parse_splice_command(&mut reader, splice_command_type, splice_command_length)?;
     let command_end_offset = reader.get_offset();
     let command_bits_read = command_end_offset - command_start_offset;
-    let command_expected_bits = splice_command_length as usize * 8;
-    if command_bits_read < command_expected_bits {
-        eprintln!(
-            "Warning: Splice command length mismatch. Expected {command_expected_bits} bits, read {command_bits_read} bits."
-        );
-        reader.skip_bits(command_expected_bits - command_bits_read)?;
+    if splice_command_length != LEGACY_SPLICE_COMMAND_LENGTH {
+        let command_expected_bits = splice_command_length as usize * 8;
+        if command_bits_read > command_expected_bits {
+            return Err(io::Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "Splice command exceeded declared splice_command_length: expected {command_expected_bits} bits, read {command_bits_read} bits"
+                ),
+            ));
+        }
+        if command_bits_read < command_expected_bits {
+            reader.skip_bits(command_expected_bits - command_bits_read)?;
+        }
     }
 
     let descriptor_loop_length = reader.read_uimsbf(16)? as u16;
@@ -89,12 +96,16 @@ pub fn parse_splice_info_section(buffer: &[u8]) -> Result<SpliceInfoSection, io:
         splice_descriptors.push(parse_splice_descriptor(&mut reader)?);
         descriptor_bits_read = reader.get_offset() - descriptor_start_offset;
     }
-    if descriptor_bits_read > descriptor_loop_length as usize * 8 {
-        eprintln!(
-            "Warning: Descriptor loop length mismatch. Expected {} bits, read {} bits.",
-            descriptor_loop_length as usize * 8,
-            descriptor_bits_read
-        );
+    let descriptor_expected_bits = descriptor_loop_length as usize * 8;
+    if descriptor_bits_read > descriptor_expected_bits {
+        return Err(io::Error::new(
+            ErrorKind::InvalidData,
+            format!(
+                "Descriptor loop exceeded declared descriptor_loop_length: expected {descriptor_expected_bits} bits, read {descriptor_bits_read} bits"
+            ),
+        ));
+    }
+    if descriptor_bits_read < descriptor_expected_bits {
         reader.skip_bits(descriptor_loop_length as usize * 8 - descriptor_bits_read)?;
     }
 
@@ -141,17 +152,14 @@ pub fn parse_splice_info_section(buffer: &[u8]) -> Result<SpliceInfoSection, io:
         section_syntax_indicator,
         private_indicator,
         sap_type,
-        section_length,
         protocol_version,
         encrypted_packet,
         encryption_algorithm,
         pts_adjustment,
         cw_index,
         tier,
-        splice_command_length,
         splice_command_type,
         splice_command,
-        descriptor_loop_length,
         splice_descriptors,
         alignment_stuffing_bits,
         e_crc_32,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,6 +2,24 @@ use super::*;
 use data_encoding::BASE64;
 use std::time::Duration;
 
+fn set_splice_command_length(buffer: &mut [u8], length: u16) {
+    assert!(length <= 0x0fff);
+    // The 12-bit splice_command_length starts in the low nibble of byte 11
+    // and continues through byte 12 in splice_info_section().
+    buffer[11] = (buffer[11] & 0xf0) | ((length >> 8) as u8 & 0x0f);
+    buffer[12] = length as u8;
+}
+
+fn refresh_crc(buffer: &mut [u8]) {
+    #[cfg(feature = "crc-validation")]
+    {
+        let crc = crate::crc::calculate_crc(&buffer[..buffer.len() - 4]).unwrap();
+        let crc_bytes = crc.to_be_bytes();
+        let crc_offset = buffer.len() - 4;
+        buffer[crc_offset..].copy_from_slice(&crc_bytes);
+    }
+}
+
 #[test]
 fn test_time_signal_command() {
     // Time Signal example from threefive: '/DAWAAAAAAAAAP/wBQb+Qjo1vQAAuwxz9A=='
@@ -43,6 +61,39 @@ fn test_time_signal_command() {
 }
 
 #[test]
+fn test_legacy_splice_command_length_for_known_command() {
+    let base64 = "/DAvAAAAAAAA///wFAVIAACPf+/+c2nALv4AUsz1AAAAAAAKAAhDVUVJAAABNWLbowo=";
+    let mut buffer = BASE64.decode(base64.as_bytes()).unwrap();
+
+    set_splice_command_length(&mut buffer, 0x0fff);
+    refresh_crc(&mut buffer);
+
+    let section = parse_splice_info_section(&buffer)
+        .expect("known commands should ignore legacy splice_command_length 0xFFF");
+
+    assert_eq!(section.splice_command_type, 0x05);
+    assert!(matches!(
+        section.splice_command,
+        SpliceCommand::SpliceInsert(_)
+    ));
+    assert_eq!(section.splice_descriptors.len(), 1);
+}
+
+#[test]
+fn test_legacy_splice_command_length_rejects_unknown_command() {
+    let base64 = "/DAWAAAAAAAAAP/wBQb+Qjo1vQAAuwxz9A==";
+    let mut buffer = BASE64.decode(base64.as_bytes()).unwrap();
+
+    set_splice_command_length(&mut buffer, 0x0fff);
+    buffer[13] = 0x08;
+    refresh_crc(&mut buffer);
+
+    let error = parse_splice_info_section(&buffer).unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+    assert!(error.to_string().contains("legacy splice_command_length"));
+}
+
+#[test]
 fn test_time_signal_with_descriptors() {
     // Time Signal with descriptors: '/DAgAAAAAAAAAP/wBQb+Qjo1vQAKAAhDVUVJAAAE0iVuWvA='
     let time_signal_desc_base64 = "/DAgAAAAAAAAAP/wBQb+Qjo1vQAKAAhDVUVJAAAE0iVuWvA=";
@@ -62,7 +113,7 @@ fn test_time_signal_with_descriptors() {
 
     // Should have descriptors
     assert!(
-        section.descriptor_loop_length > 0,
+        !section.splice_descriptors.is_empty(),
         "Should have descriptors"
     );
     assert!(
@@ -112,7 +163,7 @@ fn test_upid_adid_example_no_crc_validation() {
 
     // Should have descriptors with UPID
     assert!(
-        section.descriptor_loop_length > 0,
+        !section.splice_descriptors.is_empty(),
         "Should have descriptors for UPID"
     );
     assert!(
@@ -146,7 +197,7 @@ fn test_upid_umid_example() {
 
     // Should have descriptors with UPID
     assert!(
-        section.descriptor_loop_length > 0,
+        !section.splice_descriptors.is_empty(),
         "Should have descriptors for UPID"
     );
     assert!(
@@ -176,7 +227,7 @@ fn test_upid_isan_example() {
 
     // Should have descriptors with UPID
     assert!(
-        section.descriptor_loop_length > 0,
+        !section.splice_descriptors.is_empty(),
         "Should have descriptors for UPID"
     );
     assert!(
@@ -205,7 +256,7 @@ fn test_upid_airid_example() {
 
     // Should have multiple descriptors
     assert!(
-        section.descriptor_loop_length > 0,
+        !section.splice_descriptors.is_empty(),
         "Should have descriptors for UPID"
     );
     assert!(
@@ -260,7 +311,7 @@ fn test_time_signal_placement_opportunity_end() {
 
     // Should have descriptors indicating placement opportunity end
     assert!(
-        section.descriptor_loop_length > 0,
+        !section.splice_descriptors.is_empty(),
         "Should have descriptors for placement opportunity end"
     );
     assert!(
@@ -292,7 +343,7 @@ fn test_multiple_descriptor_types() {
     let buffer2 = BASE64.decode(time_signal_desc_base64.as_bytes()).unwrap();
     let section2 = parse_splice_info_section(&buffer2).unwrap();
     assert_eq!(section2.splice_command_type, 0x06);
-    assert!(section2.descriptor_loop_length > 0);
+    assert!(!section2.splice_descriptors.is_empty());
 
     // Test 3: Complex message with multiple descriptors (AIRID example already covered)
     let complex_base64 = "/DBhAAAAAAAA///wBQb+qM1E7QBLAhdDVUVJSAAArX+fCAgAAAAALLLXnTUCAAIXQ1VFSUgAACZ/nwgIAAAAACyy150RAAACF0NVRUlIAAAnf58ICAAAAAAsstezEAAAihiGnw==";
@@ -407,7 +458,6 @@ fn test_parse_splice_info_section() {
         section.private_indicator, 0,
         "Private indicator should be 0 (Not Private)"
     );
-    assert_eq!(section.section_length, 47, "Section length should be 47");
     assert_eq!(section.protocol_version, 0, "Protocol version should be 0");
     assert_eq!(
         section.encrypted_packet, 0,
@@ -420,10 +470,6 @@ fn test_parse_splice_info_section() {
     assert_eq!(section.tier, 0xfff, "Tier should be 0xfff");
 
     // Validate splice command fields
-    assert_eq!(
-        section.splice_command_length, 0x14,
-        "Splice command length should be 0x14"
-    );
     assert_eq!(
         section.splice_command_type, 0x05,
         "Splice command type should be 0x05 (SpliceInsert)"
@@ -484,11 +530,7 @@ fn test_parse_splice_info_section() {
         _ => panic!("Expected SpliceInsert command"),
     }
 
-    // Validate descriptor loop
-    assert_eq!(
-        section.descriptor_loop_length, 10,
-        "Descriptor loop length should be 10"
-    );
+    // Validate descriptors
     assert_eq!(
         section.splice_descriptors.len(),
         1,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,6 +3,10 @@ use data_encoding::BASE64;
 use std::time::Duration;
 
 fn set_splice_command_length(buffer: &mut [u8], length: u16) {
+    assert!(
+        buffer.len() > 12,
+        "splice_info_section buffer must include splice_command_length bytes"
+    );
     assert!(length <= 0x0fff);
     // The 12-bit splice_command_length starts in the low nibble of byte 11
     // and continues through byte 12 in splice_info_section().
@@ -10,15 +14,16 @@ fn set_splice_command_length(buffer: &mut [u8], length: u16) {
     buffer[12] = length as u8;
 }
 
+#[cfg(feature = "crc-validation")]
 fn refresh_crc(buffer: &mut [u8]) {
-    #[cfg(feature = "crc-validation")]
-    {
-        let crc = crate::crc::calculate_crc(&buffer[..buffer.len() - 4]).unwrap();
-        let crc_bytes = crc.to_be_bytes();
-        let crc_offset = buffer.len() - 4;
-        buffer[crc_offset..].copy_from_slice(&crc_bytes);
-    }
+    let crc = crate::crc::calculate_crc(&buffer[..buffer.len() - 4]).unwrap();
+    let crc_bytes = crc.to_be_bytes();
+    let crc_offset = buffer.len() - 4;
+    buffer[crc_offset..].copy_from_slice(&crc_bytes);
 }
+
+#[cfg(not(feature = "crc-validation"))]
+fn refresh_crc(_buffer: &mut [u8]) {}
 
 #[test]
 fn test_time_signal_command() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -88,21 +88,6 @@ pub enum SpliceCommand {
     Unknown,
 }
 
-impl SpliceCommand {
-    /// Returns the SCTE-35 splice command type byte for this command.
-    pub fn command_type(&self) -> u8 {
-        match self {
-            SpliceCommand::SpliceNull => 0x00,
-            SpliceCommand::SpliceSchedule(_) => 0x04,
-            SpliceCommand::SpliceInsert(_) => 0x05,
-            SpliceCommand::TimeSignal(_) => 0x06,
-            SpliceCommand::BandwidthReservation(_) => 0x07,
-            SpliceCommand::PrivateCommand(_) => 0xFF,
-            SpliceCommand::Unknown => 0xFF,
-        }
-    }
-}
-
 /// Represents a splice null command.
 ///
 /// This command indicates no splice operation should be performed.

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,8 +14,9 @@ use std::fmt;
 ///
 /// # Fields
 ///
-/// The structure follows the SCTE-35 specification layout:
-/// - Header fields (table_id, section_length, etc.)
+/// The structure follows the SCTE-35 specification layout, omitting length
+/// fields that are derived from the encoded content:
+/// - Header fields
 /// - Splice command data
 /// - Optional descriptors
 /// - CRC for data integrity
@@ -30,8 +31,6 @@ pub struct SpliceInfoSection {
     pub private_indicator: u8,
     /// SAP (Stream Access Point) type
     pub sap_type: u8,
-    /// Length of the section in bytes
-    pub section_length: u16,
     /// SCTE-35 protocol version
     pub protocol_version: u8,
     /// Encryption packet flag (0 for unencrypted)
@@ -44,14 +43,10 @@ pub struct SpliceInfoSection {
     pub cw_index: u8,
     /// Tier value for authorization
     pub tier: u16,
-    /// Length of the splice command in bytes
-    pub splice_command_length: u16,
     /// Type of splice command (0x00-0xFF)
     pub splice_command_type: u8,
     /// The actual splice command data
     pub splice_command: SpliceCommand,
-    /// Length of descriptor loop in bytes
-    pub descriptor_loop_length: u16,
     /// List of splice descriptors
     pub splice_descriptors: Vec<SpliceDescriptor>,
     /// Alignment stuffing bits for byte alignment
@@ -91,6 +86,21 @@ pub enum SpliceCommand {
     PrivateCommand(PrivateCommand),
     /// Unknown command type
     Unknown,
+}
+
+impl SpliceCommand {
+    /// Returns the SCTE-35 splice command type byte for this command.
+    pub fn command_type(&self) -> u8 {
+        match self {
+            SpliceCommand::SpliceNull => 0x00,
+            SpliceCommand::SpliceSchedule(_) => 0x04,
+            SpliceCommand::SpliceInsert(_) => 0x05,
+            SpliceCommand::TimeSignal(_) => 0x06,
+            SpliceCommand::BandwidthReservation(_) => 0x07,
+            SpliceCommand::PrivateCommand(_) => 0xFF,
+            SpliceCommand::Unknown => 0xFF,
+        }
+    }
 }
 
 /// Represents a splice null command.


### PR DESCRIPTION
## Summary

- handle legacy `splice_command_length == 0xFFF` by ignoring the length for known splice commands
- remove derived wire length fields from the public `SpliceInfoSection` model while keeping `splice_command_type`
- keep section, command, and descriptor lengths as parser/encoder internals and compute them during encoding
- update CLI, README, examples, and tests for the cleaned API

## Why

SCTE-35/2023r1 defines `0xFFF` as a backwards-compatible sentinel for `splice_command_length` that downstream equipment should ignore. The parser previously treated it as a 4095-byte command length, which could push parsing past the actual command and fail before reading descriptors.

## Validation

- `cargo fmt`
- `cargo test --all-features`

Fixes #9